### PR TITLE
Use ISyntaxReceiver to be more IDE friendly

### DIFF
--- a/Microsoft.Extensions.Logging.Generators/LoggingGenerator.Parse.cs
+++ b/Microsoft.Extensions.Logging.Generators/LoggingGenerator.Parse.cs
@@ -76,8 +76,8 @@ namespace Microsoft.Extensions.Logging.Generators
         /// </summary>
         private static IEnumerable<LoggerClass> GetLogClasses(GeneratorExecutionContext context, Compilation compilation)
         {
-            var allNodes = compilation.SyntaxTrees.SelectMany(s => s.GetRoot().DescendantNodes());
-            var allInterfaces = allNodes.Where(d => d.IsKind(SyntaxKind.InterfaceDeclaration)).OfType<InterfaceDeclarationSyntax>();
+            if (!(context.SyntaxReceiver is SyntaxReceiver receiver))
+                yield break;
 
             var logExtensionsAttribute = compilation.GetTypeByMetadataName("Microsoft.Extensions.Logging.LoggerExtensionsAttribute");
             if (logExtensionsAttribute is null)
@@ -98,7 +98,7 @@ namespace Microsoft.Extensions.Logging.Generators
             // Temp work around for https://github.com/dotnet/roslyn/pull/49330
             var semanticModelMap = new Dictionary<SyntaxTree, SemanticModel>();
 
-            foreach (var iface in allInterfaces)
+            foreach (var iface in receiver.InterfaceDeclarations)
             {
                 foreach (var al in iface.AttributeLists)
                 {

--- a/Microsoft.Extensions.Logging.Generators/LoggingGenerator.cs
+++ b/Microsoft.Extensions.Logging.Generators/LoggingGenerator.cs
@@ -2,9 +2,11 @@
 
 namespace Microsoft.Extensions.Logging.Generators
 {
+    using System.Collections.Generic;
     using System.Reflection.Metadata;
     using System.Text;
     using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Text;
 
     [Generator]
@@ -13,7 +15,7 @@ namespace Microsoft.Extensions.Logging.Generators
         /// <inheritdoc />
         public void Initialize(GeneratorInitializationContext context)
         {
-            // No initialization required for this one
+            context.RegisterForSyntaxNotifications(() => new SyntaxReceiver());
         }
 
         /// <inheritdoc />
@@ -276,6 +278,19 @@ using Microsoft.Extensions.Logging;
             }
 
             return sb.ToString();
+        }
+
+        private sealed class SyntaxReceiver : ISyntaxReceiver
+        {
+            public List<InterfaceDeclarationSyntax> InterfaceDeclarations { get; } = new();
+
+            public void OnVisitSyntaxNode(SyntaxNode syntaxNode)
+            {
+                if (syntaxNode is InterfaceDeclarationSyntax interfaceSyntax && interfaceSyntax.AttributeLists.Count > 0)
+                {
+                    InterfaceDeclarations.Add(interfaceSyntax);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The `ISyntaxReceiver` is a syntax model that is more IDE friendly than
the pull model that was previously implemented. This allows the IDE to
push data to the generator as it is processing it. This is important
because the IDE is constantly "abandoning" analysis as the customer
types in the IDE which invalidates state and they quickly want to move
to calculating the new state