### PR TITLE
Changed the samples

### DIFF
--- a/Example/Program.cs
+++ b/Example/Program.cs
@@ -56,6 +56,7 @@ namespace Example
         {
             using var loggerFactory = LoggerFactory.Create(builder =>
             {
+                builder.SetMinimumLevel(LogLevel.Trace);
                 builder.AddConsole().AddJsonConsole(o =>
                 {
                     // This will let us see the structure going to the logger


### PR DESCRIPTION
Log the actual values.

@geeknoid This reveals a problem with the ToString implementation of the LogStateHolder. We need a ToString implementation that has the format string so various loggers can fish it out as part of the structured data. 