### PR TITLE
Use other Define overload

### DIFF
--- a/Benchmark/Benchmark.csproj
+++ b/Benchmark/Benchmark.csproj
@@ -9,7 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0-preview.4.21201.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0-preview.4.21201.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Example/Example.csproj
+++ b/Example/Example.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0-preview.4.21201.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0-preview.4.21201.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LoggingGenerator.sln
+++ b/LoggingGenerator.sln
@@ -17,6 +17,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
 		LICENSE.TXT = LICENSE.TXT
+		nuget.config = nuget.config
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Microsoft.Extensions.Logging.Analyzers/Microsoft.Extensions.Logging.Analyzers.csproj
+++ b/Microsoft.Extensions.Logging.Analyzers/Microsoft.Extensions.Logging.Analyzers.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0-preview.4.21201.6" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Microsoft.Extensions.Logging.Extras/Microsoft.Extensions.Logging.Extras.csproj
+++ b/Microsoft.Extensions.Logging.Extras/Microsoft.Extensions.Logging.Extras.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0-preview.4.21201.6" />
   </ItemGroup>
 
 </Project>

--- a/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
+++ b/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
@@ -320,7 +320,7 @@ namespace Microsoft.Extensions.Logging.Generators.Test
                 {
                     public class LoggerMessageAttribute {}
                 }
-R9                partial class C
+                partial class C
                 {
                 }
             ", false, includeBaseReferences: false, includeLoggingReferences: false);

--- a/Microsoft.Extensions.Logging.Generators.Tests/MockLogger.cs
+++ b/Microsoft.Extensions.Logging.Generators.Tests/MockLogger.cs
@@ -1,7 +1,6 @@
 // © Microsoft Corporation. All rights reserved.
 
 using System;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.Logging.Generators.Test
 {
@@ -44,7 +43,7 @@ namespace Microsoft.Extensions.Logging.Generators.Test
             return Enabled;
         }
 
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {
             LastLogLevel = logLevel;
             LastEventId = eventId;

--- a/Microsoft.Extensions.Logging.Generators/LoggerMessageGenerator.Emitter.cs
+++ b/Microsoft.Extensions.Logging.Generators/LoggerMessageGenerator.Emitter.cs
@@ -520,7 +520,7 @@ namespace Microsoft.Extensions.Logging.Generators
                     return $@"
                             [{_generatedCodeAttribute}]
                             private static readonly global::System.Action<global::Microsoft.Extensions.Logging.ILogger, {GenDefineTypes(lm, false)}global::System.Exception?> __{lm.Name}Callback =
-                                global::Microsoft.Extensions.Logging.LoggerMessage.Define{GenDefineTypes(lm, true)}({level}, new global::Microsoft.Extensions.Logging.EventId({lm.EventId}, {eventName}), ""{EscapeMessageString(lm.Message!)}""); 
+                                global::Microsoft.Extensions.Logging.LoggerMessage.Define{GenDefineTypes(lm, true)}({level}, new global::Microsoft.Extensions.Logging.EventId({lm.EventId}, {eventName}), ""{EscapeMessageString(lm.Message!)}"", true); 
 
                             [{_generatedCodeAttribute}]
                             {lm.Modifiers} void {lm.Name}({extension}{GenParameters(lm)})

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
+  </packageSources>
+</configuration>
+


### PR DESCRIPTION
- Allows to get access to new LoggerMessage.Define overloads
https://github.com/dotnet/runtime/issues/45290